### PR TITLE
Update lang.js::_.getPluralForm

### DIFF
--- a/src/js/lang.js
+++ b/src/js/lang.js
@@ -328,7 +328,7 @@
      * @return {Number}
      */
     Lang.prototype._getPluralForm = function (count) {
-        switch (this.locale) {
+        switch (this.locale.substr(0,2)) {
             case 'az':
             case 'bo':
             case 'dz':


### PR DESCRIPTION
In our system, and I'm sure many others. We use a suffix country code when setting our locale for certain regions. 
ie. en_US, en_CA, en_GB.

The switch statement is based on the language code and not the locale. It should take the first two characters of the locale instead (the language code.)
