### PR TITLE
Pluralizations are per-language, while translation strings are per-locale, so isolating per-language logic to _getPluralForm

### DIFF
--- a/src/js/lang.js
+++ b/src/js/lang.js
@@ -163,11 +163,6 @@
      * @return void
      */
     Lang.prototype.setLocale = function(locale) {
-        // If a full locale is found (i.e. en_US, it will be converted to country only)
-        if(locale.indexOf('_') == 2) {
-            locale = locale.substr(0, 2)
-        }
-
         this.locale = locale;
     };
 
@@ -333,7 +328,11 @@
      * @return {Number}
      */
     Lang.prototype._getPluralForm = function (count) {
-        switch (this.locale) {
+        
+        // If a full locale is found (i.e. en_US), parse the 2-letter lang code from before the underscore
+        var lang = (this.locale.indexOf('_') == 2) ? this.locale.substr(0, 2) : this.locale;
+
+        switch (lang) {
             case 'az':
             case 'bo':
             case 'dz':


### PR DESCRIPTION
The latest change was still broken:  When the Locale is changed to "en" from "en_US", it could not find any of the translations, as they are keyed per-locale.  

The rest of the translation logic should be locale-specific, it is only the pluralization logic which is language-specific.
